### PR TITLE
fix passing of gathered headers

### DIFF
--- a/src/contajners/core.cljc
+++ b/src/contajners/core.cljc
@@ -85,7 +85,7 @@
                                                     :path
                                                     (impl/interpolate-path (:path request-params))
                                                     (as-> path (str "/" version path)))
-                          :headers              (:headers request-params)
+                          :headers              (:header request-params)
                           :query-params         (:query request-params)
                           :body                 data
                           :as                   as


### PR DESCRIPTION
Just a simple typo, but a fatal one: x-registry-auth cannot be passed currently.