### PR TITLE
Update building exaple to allow streaming output to *out*

### DIFF
--- a/doc/001-api.md
+++ b/doc/001-api.md
@@ -145,3 +145,5 @@ Takes another optional key `:throw-exceptions`. Defaults to `false`. If set to t
 {:op               :NameOfOp
  :throw-exceptions true}
 ```
+
+In general if any param is documented to take a file or a binary string, pass an [input-stream](https://clojuredocs.org/clojure.java.io/input-stream) to it. This would not only make it more efficient but should keep the encoding correct. For example: https://docs.docker.com/engine/api/v1.41/#operation/ImageLoad


### PR DESCRIPTION
It might add a bit of noise to the example, but I think it is helpful to have the output of the command print in the shell :-)