### PR TITLE
fix option name; remove debug print

### DIFF
--- a/src/contajners/sci_runtime.clj
+++ b/src/contajners/sci_runtime.clj
@@ -14,11 +14,10 @@
 
 (defn client
   [uri {:keys [connect-timeout-ms call-timeout-ms mtls]}]
-  (prn uri connect-timeout-ms call-timeout-ms mtls)
   (let [unix (unix-socket? uri)]
     {:raw-args (cond-> []
                  connect-timeout-ms (conj "--connect-timeout" (as-sec-str connect-timeout-ms))
-                 call-timeout-ms (conj "--max-timeout" (as-sec-str call-timeout-ms))
+                 call-timeout-ms (conj "--max-time" (as-sec-str call-timeout-ms))
                  unix (conj "--unix-socket" (.getPath (URI. uri)))
                  mtls (conj "--cacert" (:ca mtls) "--key" (:key mtls) "--cert" (:cert mtls)))
      :url (if unix "http://localhost" uri)}))


### PR DESCRIPTION
Hi there!

When using `contajners` with `Babashka`, `curl` arguments are populated by `contajners.sci-runtime/client`.
It seems that there's an error with the `call-timeout-ms` option: It should be `"--max-time"` rather than `"--max-timeout"`.
Please see <https://curl.se/docs/manpage.html#-m>.

Also there's something that looks like a forgotten debug in the same `contajners.sci-runtime` namespace.